### PR TITLE
Use the C# parameter name for the script parameter name

### DIFF
--- a/src/TypeRight.Core/ScriptWriting/TypeScript/ScriptExtensions/UrlParamsScriptExtensions.cs
+++ b/src/TypeRight.Core/ScriptWriting/TypeScript/ScriptExtensions/UrlParamsScriptExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using TypeRight.ScriptWriting.TypeScript.PartialTextTemplates;
+using TypeRight.TypeProcessing;
 
 namespace TypeRight.ScriptWriting.TypeScript.ScriptExtensions
 {
@@ -19,16 +20,16 @@ namespace TypeRight.ScriptWriting.TypeScript.ScriptExtensions
 	/// </summary>
 	internal class AddSimpleParameterToQueryStringScriptExtension : IScriptExtension
 	{
-		private string _paramName;
+		private readonly MvcActionParameter _param;
 
-		public AddSimpleParameterToQueryStringScriptExtension(string paramName)
+		public AddSimpleParameterToQueryStringScriptExtension(MvcActionParameter param)
 		{
-			_paramName = paramName;
+			_param = param;
 		}
 
 		public void Write(IScriptWriter writer)
 		{
-			writer.WriteLine($"{QueryParameterHelperFunctions.TryAppendKeyValueFuncName}({InitUrlParamsScriptExtensions.UrlParamsVarName}, \"{_paramName}\", {_paramName});");
+			writer.WriteLine($"{QueryParameterHelperFunctions.TryAppendKeyValueFuncName}({InitUrlParamsScriptExtensions.UrlParamsVarName}, \"{_param.ApiName}\", {_param.Name});");
 		}
 	}
 
@@ -51,16 +52,16 @@ namespace TypeRight.ScriptWriting.TypeScript.ScriptExtensions
 
 	internal class AddComplexParameterToQueryStringScriptExtension : IScriptExtension
 	{
-		private string _paramName;
+		private readonly MvcActionParameter _param;
 
-		public AddComplexParameterToQueryStringScriptExtension(string paramName)
+		public AddComplexParameterToQueryStringScriptExtension(MvcActionParameter param)
 		{
-			_paramName = paramName;
+			_param = param;
 		}
 
 		public void Write(IScriptWriter writer)
 		{
-			writer.WriteLine($"{QueryParameterHelperFunctions.TryAppendObjectFuncName}({InitUrlParamsScriptExtensions.UrlParamsVarName}, {_paramName});");
+			writer.WriteLine($"{QueryParameterHelperFunctions.TryAppendObjectFuncName}({InitUrlParamsScriptExtensions.UrlParamsVarName}, {_param.Name});");
 		}
 	}
 }

--- a/src/TypeRight.Core/ScriptWriting/TypeScript/ScriptExtensionsFactory.cs
+++ b/src/TypeRight.Core/ScriptWriting/TypeScript/ScriptExtensionsFactory.cs
@@ -38,7 +38,7 @@ namespace TypeRight.ScriptWriting.TypeScript
 
 				foreach (var queryP in GetSimpleQueryParams(action))
 				{
-					exts.Add(new AddSimpleParameterToQueryStringScriptExtension(queryP.Name));
+					exts.Add(new AddSimpleParameterToQueryStringScriptExtension(queryP));
 				}
 
 				foreach (string key in _constantQueryParams.Keys)
@@ -51,7 +51,7 @@ namespace TypeRight.ScriptWriting.TypeScript
 
 				foreach (var queryP in GetComplexQueryParams(action))
 				{
-					exts.Add(new AddComplexParameterToQueryStringScriptExtension(queryP.Name));
+					exts.Add(new AddComplexParameterToQueryStringScriptExtension(queryP));
 				}
 
 			}

--- a/src/TypeRight.Core/TypeProcessing/MvcAction.cs
+++ b/src/TypeRight.Core/TypeProcessing/MvcAction.cs
@@ -181,22 +181,29 @@ namespace TypeRight.TypeProcessing
 
 		private ActionParameterSourceType? _bindingType;
 		private readonly string _origName;
-		private string _name;
+		private string _apiName;
 
 		internal MvcAction Action { get; }
 
-        /// <summary>
-        /// Gets the name of the parameter
-        /// </summary>
-        public string Name
+		/// <summary>
+		/// Gets the name of the parameter, as defined in C#
+		/// </summary>
+		public string Name => _origName;
+
+		/// <summary>
+		/// Gets the name of the parameter, as expected by the API.
+		/// For example, as a query parameter if changed via FromQuery
+		/// </summary>
+		public string ApiName
 		{
+
 			get
 			{
-				if (string.IsNullOrEmpty(_name))
+				if (string.IsNullOrEmpty(_apiName))
 				{
-					_name = ComputeName();
+					_apiName = ComputeApiName();
 				}
-				return _name;
+				return _apiName;
 			}
 		}
 
@@ -246,7 +253,7 @@ namespace TypeRight.TypeProcessing
 			IsOptional = false;
 		}
 
-		private string ComputeName()
+		private string ComputeApiName()
 		{
 			IAttributeData fromQueryAttr = s_queryParamFilter.GetAttribute(this);
 			if (fromQueryAttr is null 

--- a/test/TestProjects/AspNetCore/TestAspNetCoreApp/Scripts/Home/CustomNamedActions.ts
+++ b/test/TestProjects/AspNetCore/TestAspNetCoreApp/Scripts/Home/CustomNamedActions.ts
@@ -58,10 +58,11 @@ export function complexWithListFromQuery(fromQueryModel: Partial<ServerObjects.M
 
 /**
  * 
+ * @param searchText 
  */
-export function fromQueryNewName(q: string, abort?: AbortSignal): Promise<string[]> {
+export function fromQueryNewName(searchText: string, abort?: AbortSignal): Promise<string[]> {
 	const urlParams = new URLSearchParams();
-	tryAppendKeyValueToUrl(urlParams, "q", q);
+	tryAppendKeyValueToUrl(urlParams, "q", searchText);
 	tryAppendKeyValueToUrl(urlParams, "param1", "val1");
 	tryAppendKeyValueToUrl(urlParams, "param2", "val2");
 	return fetchWrapper("GET", `/api/TestWebApi${getQueryString(urlParams)}`, null, abort);

--- a/test/TypeRight.Tests/Controllers/AspNetCore/ControllerAttributesTests.cs
+++ b/test/TypeRight.Tests/Controllers/AspNetCore/ControllerAttributesTests.cs
@@ -55,9 +55,9 @@ export function TestAction(fromQuery: string): void {{
 			;
 
 			AssertScriptTextForFunctionIs(@$"
-export function TestAction(q: string): void {{
+export function TestAction(fromQuery: string): void {{
 	const urlParams = new URLSearchParams();
-	tryAppendKeyValueToUrl(urlParams, ""q"", q);
+	tryAppendKeyValueToUrl(urlParams, ""q"", fromQuery);
 	fetchWrapper(""GET"", `/{ControllerName}/TestAction${{getQueryString(urlParams)}}`, null);
 }}", ScriptExtensions.KeyValueQueryParamHelper);
 		}


### PR DESCRIPTION
Closes #134 

Reserved keywords could be added as the `FromQuery` parameter name, which breaks typescript. Go back to using the C# parameter name as the script variable, but put the `FromQuery` name in the URL parameter